### PR TITLE
Use effect for project filter updates

### DIFF
--- a/src/components/ProjectFilter.tsx
+++ b/src/components/ProjectFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { motion } from 'motion/react';
 import { Search, Filter, X } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -44,8 +44,7 @@ export default function ProjectFilter({ onFilteredProjects }: ProjectFilterProps
     return filtered;
   }, [searchTerm, selectedCategory]);
 
-  // Update parent component when filtered projects change
-  useMemo(() => {
+  useEffect(() => {
     onFilteredProjects(filteredProjects);
   }, [filteredProjects, onFilteredProjects]);
 


### PR DESCRIPTION
## Summary
- replace the memoized callback with a useEffect that notifies parents when the filtered project list changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b860bffc832aa66a92d967c70d1a