### PR TITLE
Localize project filter UI strings

### DIFF
--- a/src/components/ProjectFilter.tsx
+++ b/src/components/ProjectFilter.tsx
@@ -70,7 +70,11 @@ export default function ProjectFilter({ onFilteredProjects }: ProjectFilterProps
           whileTap={{ scale: 0.95 }}
         >
           <Filter size={16} />
-          <span>{isExpanded ? 'Hide' : 'Filter'}</span>
+          <span>
+            {isExpanded
+              ? t('projects.filters.toggle.hide')
+              : t('projects.filters.toggle.show')}
+          </span>
         </motion.button>
       </div>
 
@@ -90,7 +94,7 @@ export default function ProjectFilter({ onFilteredProjects }: ProjectFilterProps
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={16} />
             <input
               type="text"
-              placeholder="Search projects by name, technology, or category..."
+              placeholder={t('projects.filters.searchPlaceholder')}
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="w-full pl-10 pr-4 py-2 bg-slate-700/50 border border-slate-600/50 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500/50 focus:bg-slate-700/70 transition-all duration-300"
@@ -135,7 +139,7 @@ export default function ProjectFilter({ onFilteredProjects }: ProjectFilterProps
               whileTap={{ scale: 0.95 }}
             >
               <X size={14} />
-              Clear filters
+              {t('projects.filters.clear')}
             </motion.button>
           )}
         </div>

--- a/src/components/TranslatedSections.tsx
+++ b/src/components/TranslatedSections.tsx
@@ -86,8 +86,12 @@ export default function TranslatedSections() {
           </div>
         ) : (
           <div className="text-center py-12">
-            <div className="text-gray-400 text-lg mb-2">No projects found</div>
-            <div className="text-gray-500 text-sm">Try adjusting your search or filter criteria</div>
+            <div className="text-gray-400 text-lg mb-2">
+              {t('projects.filters.empty.title')}
+            </div>
+            <div className="text-gray-500 text-sm">
+              {t('projects.filters.empty.description')}
+            </div>
           </div>
         )}
       </Section>

--- a/src/lib/translations/de.ts
+++ b/src/lib/translations/de.ts
@@ -43,6 +43,18 @@ export const de = {
       personal: 'Persönlich',
       freelance: 'Freelance',
     },
+    filters: {
+      toggle: {
+        show: 'Filter anzeigen',
+        hide: 'Filter ausblenden',
+      },
+      searchPlaceholder: 'Suche nach Projekten nach Name, Technologie oder Kategorie...',
+      clear: 'Filter zurücksetzen',
+      empty: {
+        title: 'Keine Projekte gefunden',
+        description: 'Versuche, deine Suche oder Filterkriterien anzupassen',
+      },
+    },
   },
   
   playground: {

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -43,6 +43,18 @@ export const en = {
       personal: 'Personal',
       freelance: 'Freelance',
     },
+    filters: {
+      toggle: {
+        show: 'Show filters',
+        hide: 'Hide filters',
+      },
+      searchPlaceholder: 'Search projects by name, technology, or category...',
+      clear: 'Clear filters',
+      empty: {
+        title: 'No projects found',
+        description: 'Try adjusting your search or filter criteria',
+      },
+    },
   },
   
   playground: {

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -43,6 +43,18 @@ export const es = {
       personal: 'Personal',
       freelance: 'Freelance',
     },
+    filters: {
+      toggle: {
+        show: 'Mostrar filtros',
+        hide: 'Ocultar filtros',
+      },
+      searchPlaceholder: 'Busca proyectos por nombre, tecnología o categoría...',
+      clear: 'Limpiar filtros',
+      empty: {
+        title: 'No se encontraron proyectos',
+        description: 'Intenta ajustar tu búsqueda o los criterios de filtrado',
+      },
+    },
   },
   
   playground: {

--- a/src/lib/translations/fr.ts
+++ b/src/lib/translations/fr.ts
@@ -43,6 +43,18 @@ export const fr = {
       personal: 'Personnel',
       freelance: 'Freelance',
     },
+    filters: {
+      toggle: {
+        show: 'Afficher les filtres',
+        hide: 'Masquer les filtres',
+      },
+      searchPlaceholder: 'Rechercher des projets par nom, technologie ou catégorie...',
+      clear: 'Effacer les filtres',
+      empty: {
+        title: 'Aucun projet trouvé',
+        description: 'Essayez d’ajuster votre recherche ou vos critères de filtre',
+      },
+    },
   },
   
   playground: {

--- a/src/lib/translations/index.ts
+++ b/src/lib/translations/index.ts
@@ -46,9 +46,22 @@ export interface Translations {
     viewCode: string;
     moreTechnologies: string;
     categories: {
+      all: string;
       work: string;
       personal: string;
       freelance: string;
+    };
+    filters: {
+      toggle: {
+        show: string;
+        hide: string;
+      };
+      searchPlaceholder: string;
+      clear: string;
+      empty: {
+        title: string;
+        description: string;
+      };
     };
   };
   

--- a/src/lib/translations/no.ts
+++ b/src/lib/translations/no.ts
@@ -43,6 +43,18 @@ export const no = {
       personal: 'Personlig',
       freelance: 'Frilans',
     },
+    filters: {
+      toggle: {
+        show: 'Vis filtre',
+        hide: 'Skjul filtre',
+      },
+      searchPlaceholder: 'Søk etter prosjekter etter navn, teknologi eller kategori...',
+      clear: 'Nullstill filtre',
+      empty: {
+        title: 'Ingen prosjekter funnet',
+        description: 'Prøv å justere søket eller filtervalgene dine',
+      },
+    },
   },
   
   playground: {


### PR DESCRIPTION
## Summary
- extend the translations index and language files with keys for project filters and empty states
- update the project filter component to use localized toggle, placeholder, and clear button text
- localize the projects empty state messaging in the translated sections component

## Testing
- npm run lint *(fails: existing lint warnings and errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b8617478832aa001fccf6417d6bd